### PR TITLE
Fix reverting get names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ dist: trusty
 language: node_js
 
 node_js:
-  - '14'
+  - '18'
 install:
-  - npm install
+  - npm install -g yarn
+  - yarn
 env:
   - TASK=test
 matrix:
@@ -17,7 +18,7 @@ before_script:
   - ganache-cli > /dev/null &
   - sleep 5
 script:
-  - npm run $TASK
+  - yarn $TASK
 
 notifications:
   email: false

--- a/test/ReverseRecords.js
+++ b/test/ReverseRecords.js
@@ -46,7 +46,9 @@ describe("ReverseRecords contract", function() {
       // eAddr: ower of e.eth and resolver set but no forward address set
       // fAddr: set empty string to reverse record
       // gAddr: correct
-      const [owner, aAddr, bAddr, cAddr, dAddr, eAddr, fAddr, gAddr] = await ethers.getSigners();
+      // hAddr: set resolver as an EOA
+      // iAddr: set resolver with a wrong interface
+      const [owner, aAddr, bAddr, cAddr, dAddr, eAddr, fAddr, gAddr, hAddr, iAddr] = await ethers.getSigners();
       const PublicResolver = await ethers.getContractFactory("PublicResolver");
       const resolverArtifact = await hre.artifacts.readArtifact("PublicResolver")
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('a'), aAddr.address);
@@ -56,6 +58,8 @@ describe("ReverseRecords contract", function() {
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('e'), eAddr.address);
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('f'), fAddr.address);
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('g'), gAddr.address);
+      await ens.setSubnodeOwner(namehash.hash('eth'), sha3('h'), hAddr.address);
+      await ens.setSubnodeOwner(namehash.hash('eth'), sha3('i'), iAddr.address);
 
       await ens.connect(aAddr).setResolver(namehash.hash('a.eth'), resolver.address)
       await ens.connect(bAddr).setResolver(namehash.hash('b.eth'), resolver.address)
@@ -64,6 +68,8 @@ describe("ReverseRecords contract", function() {
       await ens.connect(eAddr).setResolver(namehash.hash('e.eth'), resolver.address)
       await ens.connect(fAddr).setResolver(namehash.hash('f.eth'), resolver.address)
       await ens.connect(gAddr).setResolver(namehash.hash('g.eth'), resolver.address)
+      await ens.connect(hAddr).setResolver(namehash.hash('h.eth'), hAddr.address)
+      await ens.connect(iAddr).setResolver(namehash.hash('i.eth'), ens.address)
 
       // Setting forward records
       await await resolver.connect(aAddr)['setAddr(bytes32,address)'](namehash.hash('a.eth'), aAddr.address);
@@ -82,6 +88,7 @@ describe("ReverseRecords contract", function() {
       await registrar.connect(eAddr).setName('e.eth')
       await registrar.connect(fAddr).setName('')
       await registrar.connect(gAddr).setName('g.eth')
+      await registrar.connect(hAddr).setName('h.eth')
 
       const ReverseRecords = await ethers.getContractFactory("ReverseRecords");
       const reverseRecords = await ReverseRecords.deploy(ens.address);
@@ -92,8 +99,11 @@ describe("ReverseRecords contract", function() {
         dAddr.address,
         eAddr.address,
         fAddr.address,
-        gAddr.address
+        gAddr.address,
+        hAddr.address,
+        iAddr.address
       ]);
+
       expect(await assertReverseRecord(ens, aAddr.address)).to.be.true
       expect(results[0]).to.equal('a.eth');
       expect(await assertReverseRecord(ens, bAddr.address)).to.be.false
@@ -108,5 +118,9 @@ describe("ReverseRecords contract", function() {
       expect(results[5]).to.equal('');
       expect(await assertReverseRecord(ens, gAddr.address)).to.be.true
       expect(results[6]).to.equal('g.eth');
+      expect(await assertReverseRecord(ens, hAddr.address)).to.be.false
+      expect(results[7]).to.equal('');
+      expect(await assertReverseRecord(ens, iAddr.address)).to.be.false
+      expect(results[8]).to.equal('');
     });
 });

--- a/test/ReverseRecords.js
+++ b/test/ReverseRecords.js
@@ -42,8 +42,8 @@ describe("ReverseRecords contract", function() {
       // aAddr: correct
       // bAddr: no reverse record set
       // cAddr: not the owner of c.eth
-      // dAddr: ower of d.eth but no resolver set
-      // eAddr: ower of e.eth and resolver set but no forward address set
+      // dAddr: owner of d.eth but no resolver set
+      // eAddr: owner of e.eth and resolver set but no forward address set
       // fAddr: set empty string to reverse record
       // gAddr: correct
       // hAddr: set resolver as an EOA

--- a/test/ReverseRecords.js
+++ b/test/ReverseRecords.js
@@ -24,7 +24,7 @@ async function assertReverseRecord(ens, address){
 describe("ReverseRecords contract", function() {
     let node, ens, resolver, registrar, ethNode
     before(async () => {
-      const [owner, aAddr, bAddr, cAddr, dAddr, eAddr, fAddr, gAddr] = await ethers.getSigners();
+      const [owner] = await ethers.getSigners();
       ethNode = namehash.hash('eth')
       node = namehash.hash(owner.address.slice(2).toLowerCase() + ".addr.reverse");
       const ENSRegistry = await ethers.getContractFactory("ENSRegistry");
@@ -49,8 +49,6 @@ describe("ReverseRecords contract", function() {
       // hAddr: set resolver as an EOA
       // iAddr: set resolver with a wrong interface
       const [owner, aAddr, bAddr, cAddr, dAddr, eAddr, fAddr, gAddr, hAddr, iAddr] = await ethers.getSigners();
-      const PublicResolver = await ethers.getContractFactory("PublicResolver");
-      const resolverArtifact = await hre.artifacts.readArtifact("PublicResolver")
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('a'), aAddr.address);
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('b'), bAddr.address);
       // No c
@@ -68,8 +66,10 @@ describe("ReverseRecords contract", function() {
       await ens.connect(eAddr).setResolver(namehash.hash('e.eth'), resolver.address)
       await ens.connect(fAddr).setResolver(namehash.hash('f.eth'), resolver.address)
       await ens.connect(gAddr).setResolver(namehash.hash('g.eth'), resolver.address)
+      // Set the resolver to a non contract address
       await ens.connect(hAddr).setResolver(namehash.hash('h.eth'), hAddr.address)
-      await ens.connect(iAddr).setResolver(namehash.hash('i.eth'), ens.address)
+
+      await ens.connect(iAddr).setResolver(namehash.hash('i.eth'), resolver.address)
 
       // Setting forward records
       await await resolver.connect(aAddr)['setAddr(bytes32,address)'](namehash.hash('a.eth'), aAddr.address);
@@ -80,6 +80,8 @@ describe("ReverseRecords contract", function() {
       await await resolver.connect(fAddr)['setAddr(bytes32,address)'](namehash.hash('f.eth'), fAddr.address);
       await await resolver.connect(gAddr)['setAddr(bytes32,address)'](namehash.hash('g.eth'), gAddr.address);
 
+      await await resolver.connect(iAddr)['setAddr(bytes32,address)'](namehash.hash('i.eth'), iAddr.address);
+
       // Setting reverse record
       await registrar.connect(aAddr).setName('a.eth')
       // No reverse record set on b
@@ -89,9 +91,14 @@ describe("ReverseRecords contract", function() {
       await registrar.connect(fAddr).setName('')
       await registrar.connect(gAddr).setName('g.eth')
       await registrar.connect(hAddr).setName('h.eth')
+      await registrar.connect(iAddr).setName('i.eth')
 
       const ReverseRecords = await ethers.getContractFactory("ReverseRecords");
       const reverseRecords = await ReverseRecords.deploy(ens.address);
+
+      // Set a good resolver to a contract that doesn't support the function
+      await ens.connect(iAddr).setResolver(namehash.hash('i.eth'), reverseRecords.address)
+
       const results = await reverseRecords.getNames([
         aAddr.address,
         bAddr.address,

--- a/test/ReverseRecords.js
+++ b/test/ReverseRecords.js
@@ -49,6 +49,8 @@ describe("ReverseRecords contract", function() {
       // hAddr: set resolver as an EOA
       // iAddr: set resolver with a wrong interface
       const [owner, aAddr, bAddr, cAddr, dAddr, eAddr, fAddr, gAddr, hAddr, iAddr] = await ethers.getSigners();
+      const PublicResolver = await ethers.getContractFactory("PublicResolver");
+      const resolverArtifact = await hre.artifacts.readArtifact("PublicResolver")
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('a'), aAddr.address);
       await ens.setSubnodeOwner(namehash.hash('eth'), sha3('b'), bAddr.address);
       // No c


### PR DESCRIPTION
Fix reverting get name when:

- An address has a reverse record that is not a contract
- An address has a reverse record that it's a contract that doesn't support the interface

